### PR TITLE
Remove moddrop

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -428,7 +428,6 @@
 ||modcraft.biz^$all
 ||modcraft.su^$all
 ||moddingames.wordpress.com^$all
-||moddrop.com^$all
 ||moddrops.weebly.com^$all
 ||modfast.ru^$all
 ||modminecraft.com^$all


### PR DESCRIPTION
Moddrop is not a site that reposts mods - all content is user generated (like curseforge, nexus mods, gamebanana etc).
